### PR TITLE
fix ping_google in localhost or testing environments

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -68,11 +68,11 @@ class Post(models.Model):
         """Represent by its title."""
         return str(self.title)
 
-    def publish(self):
+    def publish(self, request=None):
         """Publish a blog post by setting its published date."""
         self.published = timezone.now()
         self.save()
-        post_published.send(sender=Post, instance=self)
+        post_published.send(sender=Post, instance=self, request=request)
 
     @property
     def is_draft(self) -> bool:

--- a/blog/signals.py
+++ b/blog/signals.py
@@ -1,16 +1,31 @@
 """Blog signals."""
 
-from django.conf import settings
 from django.contrib.sitemaps import ping_google
+from django.contrib.sites.shortcuts import get_current_site
 from django.dispatch import Signal, receiver
 
-post_published = Signal(providing_args=['instance'])
+post_published = Signal(providing_args=['instance', 'request'])
 
 
 @receiver(post_published)
-def ping_google_on_publish_post(sender, instance, **kwargs):
+def ping_google_on_publish_post(sender, instance, request=None, **kwargs):
     """Let Google know that sitemap was updated when a post is published."""
-    if settings.TESTING:
-        print('Skipped ping_google() because this was a test')
-    else:
-        ping_google()
+    def _skip(reason: str):
+        print('Skipped ping_google because', reason)
+
+    if request is None:
+        _skip('no request was given')
+        return
+
+    site = get_current_site(request)
+
+    if 'localhost' in site.domain:
+        _skip('running on localhost')
+        return
+
+    if site.domain == 'example.com':
+        _skip('most definitely testing')
+        return
+
+    ping_google()
+    print('Pinged Google about updated sitemap')

--- a/blog/views.py
+++ b/blog/views.py
@@ -29,6 +29,6 @@ class PostViewSet(viewsets.ModelViewSet):
     def publication(self, request, **kwargs):
         """Publish a blog post."""
         post = self.get_object()
-        post.publish()
+        post.publish(request)
         serializer = self.get_serializer(instance=post)
         return Response(serializer.data)

--- a/personal/settings/common.py
+++ b/personal/settings/common.py
@@ -15,9 +15,6 @@ SECRET_KEY = os.getenv('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv('DEBUG', False)
 
-# Whether we're running tests
-TESTING = 'test' in sys.argv
-
 ALLOWED_HOSTS = [
     'localhost',
     '127.0.0.1',


### PR DESCRIPTION
# Description

The call to `ping_google()` when a post was published could fail if running on `localhost` (because the sitemap URL was pointing at `localhost` which Google could not retrieve).

Better handle that case, and others.