### PR TITLE
WIP: Implement cursor pagination on post list

### DIFF
--- a/blog/pagination.py
+++ b/blog/pagination.py
@@ -1,0 +1,10 @@
+"""Blog pagination classes."""
+
+from rest_framework.pagination import CursorPagination
+
+
+class PostPagination(CursorPagination):
+    """Pagination configuration for blog posts."""
+
+    page_size = 10  # Must be set, non-configurable by client
+    ordering = '-created'  # The default

--- a/blog/views.py
+++ b/blog/views.py
@@ -11,6 +11,7 @@ from django_filters.rest_framework.backends import DjangoFilterBackend
 from .filters import PostFilter
 from .models import Post
 from .serializers import PostDetailSerializer, PostSerializer
+from .pagination import PostPagination
 
 
 class PostViewSet(viewsets.ModelViewSet):
@@ -21,6 +22,7 @@ class PostViewSet(viewsets.ModelViewSet):
     lookup_field = 'slug'
     filter_backends = (DjangoFilterBackend,)
     filterset_class = PostFilter
+    pagination_class = PostPagination
 
     def get_serializer_class(self):
         if self.action == 'retrieve':

--- a/tests/test_blog/test_post_list.py
+++ b/tests/test_blog/test_post_list.py
@@ -1,5 +1,6 @@
 """Test list of blog posts."""
 
+from typing import List
 from rest_framework.test import APITestCase
 from tests.decorators import authenticated
 
@@ -28,40 +29,40 @@ class PostListTest(APITestCase):
     def setUp(self):
         PostFactory.create_batch(3)
 
-    def perform(self, **params):
+    def perform(self, **params) -> List[dict]:
         response = self.client.get('/api/posts/', params)
         self.assertEqual(response.status_code, 200)
-        return response
+        return response.data['results']
 
     def test_list(self):
-        response = self.perform()
-        self.assertEqual(len(response.data), 3)
+        posts = self.perform()
+        self.assertEqual(len(posts), 3)
 
     def test_returns_expected_fields(self):
-        response = self.perform()
+        posts = self.perform()
         expected = _POST_FIELDS
-        self.assertSetEqual(expected, set(response.data[0]))
+        self.assertSetEqual(expected, set(posts[0]))
 
     def test_filter_by_slug(self):
         post = PostFactory.create(title='Hello, world!', slug='hello-world')
-        response = self.perform(slug=post.slug)
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['slug'], 'hello-world')
+        posts = self.perform(slug=post.slug)
+        self.assertEqual(len(posts), 1)
+        self.assertEqual(posts[0]['slug'], 'hello-world')
 
     def test_filter_not_draft_returns_published_only(self):
         post = PostFactory.create()
         post.publish()
-        response = self.perform(draft=False)
-        self.assertEqual(len(response.data), 1)
-        post_data = response.data[0]
+        posts = self.perform(draft=False)
+        self.assertEqual(len(posts), 1)
+        post_data = posts[0]
         self.assertEqual(post_data['id'], post.pk)
         self.assertFalse(post_data['is_draft'])
 
     def test_filter_draft_returns_drafts_only(self):
         post = PostFactory.create()
         post.publish()
-        response = self.perform(draft=True)
-        self.assertEqual(len(response.data), 3)
-        self.assertNotIn(post.pk, map(lambda post: post['id'], response.data))
-        for post in response.data:
+        posts = self.perform(draft=True)
+        self.assertEqual(len(posts), 3)
+        self.assertNotIn(post.pk, map(lambda post: post['id'], posts))
+        for post in posts:
             self.assertTrue(post['is_draft'])

--- a/tests/test_blog/test_post_tags.py
+++ b/tests/test_blog/test_post_tags.py
@@ -1,5 +1,7 @@
 """Test blog post tags."""
 
+from typing import List
+
 from django.test import TestCase
 from rest_framework.test import APITestCase
 from tests.decorators import authenticated
@@ -12,21 +14,21 @@ from blog.factories import PostFactory
 class SearchByTagTest(APITestCase):
     """Test the filtering of the blog post list for a given tag."""
 
-    def perform(self):
+    def perform(self) -> List[dict]:
         url = '/api/posts/'
         response = self.client.get(url, data={'tag': 'python'})
         self.assertEqual(response.status_code, 200)
-        return response
+        return response.data['results']
 
     def test_if_post_has_tag_then_included(self):
         PostFactory.create(tags=['python', 'webdev'])
-        response = self.perform()
-        self.assertEqual(len(response.data), 1)
+        posts = self.perform()
+        self.assertEqual(len(posts), 1)
 
     def test_if_post_does_not_have_tag_then_not_included(self):
         PostFactory.create(tags=['javascript', 'webdev'])
-        response = self.perform()
-        self.assertEqual(len(response.data), 0)
+        posts = self.perform()
+        self.assertEqual(len(posts), 0)
 
 
 class DistinctTagsTest(TestCase):


### PR DESCRIPTION
# Description

Add cursor pagination on the list of posts. Allows to load posts 10 by 10. First step to infinite scroll. :boom:

## Deployment notes

The format of `list` endpoints changes slightly: instead of returning a list of posts, that list is now available in the `"results"` field.

The frontend should first be updated to support both formats.