### PR TITLE
Add search capabilities on post list

### DIFF
--- a/blog/filters.py
+++ b/blog/filters.py
@@ -21,4 +21,4 @@ class PostFilter(filters.FilterSet):
 
     class Meta:  # noqa
         model = Post
-        fields = ('slug', 'tag')
+        fields = ('draft', 'tag',)

--- a/blog/models.py
+++ b/blog/models.py
@@ -73,7 +73,7 @@ class Post(models.Model):
 
     def save(self, *args, **kwargs):
         """Set slug when creating a post."""
-        if not self.pk:
+        if not self.pk and not self.slug:
             self.slug = slugify(self.title)[:self.SLUG_MAX_LENGTH]
         return super().save(*args, **kwargs)
 

--- a/blog/views.py
+++ b/blog/views.py
@@ -3,6 +3,7 @@
 from collections import Counter
 
 from rest_framework import viewsets
+from rest_framework.filters import SearchFilter
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
@@ -10,8 +11,8 @@ from django_filters.rest_framework.backends import DjangoFilterBackend
 
 from .filters import PostFilter
 from .models import Post
-from .serializers import PostDetailSerializer, PostSerializer
 from .pagination import PostPagination
+from .serializers import PostDetailSerializer, PostSerializer
 
 
 class PostViewSet(viewsets.ModelViewSet):
@@ -20,8 +21,9 @@ class PostViewSet(viewsets.ModelViewSet):
     queryset = Post.objects.all()
     serializer_class = PostSerializer
     lookup_field = 'slug'
-    filter_backends = (DjangoFilterBackend,)
+    filter_backends = (SearchFilter, DjangoFilterBackend,)
     filterset_class = PostFilter
+    search_fields = ('title', 'slug')
     pagination_class = PostPagination
 
     def get_serializer_class(self):

--- a/tests/test_blog/test_post_filter.py
+++ b/tests/test_blog/test_post_filter.py
@@ -1,0 +1,64 @@
+"""Test list of blog posts."""
+
+from datetime import timedelta
+from time import sleep
+from typing import List
+
+from django.utils import timezone
+from rest_framework.test import APITestCase
+from tests.decorators import authenticated
+
+from blog.factories import PostFactory
+
+
+@authenticated
+class PostFilterListTest(APITestCase):
+    """Test filtering the post list endpoint."""
+
+    def perform(self, **params) -> List[dict]:
+        response = self.client.get('/api/posts/', params)
+        self.assertEqual(response.status_code, 200)
+        return response.data['results']
+
+    def test_filter_by_slug(self):
+        post = PostFactory.create(title='Hello, world!', slug='hello-world')
+        posts = self.perform(slug=post.slug)
+        self.assertEqual(len(posts), 1)
+        self.assertEqual(posts[0]['slug'], 'hello-world')
+
+    def test_filter_not_draft_returns_published_only(self):
+        post = PostFactory.create()
+        post.publish()
+        posts = self.perform(draft=False)
+        self.assertEqual(len(posts), 1)
+        post_data = posts[0]
+        self.assertEqual(post_data['id'], post.pk)
+        self.assertFalse(post_data['is_draft'])
+
+    def test_filter_not_draft_returns_in_published_date_order(self):
+        now = timezone.now()
+        yesterday = timezone.now() - timedelta(days=1)
+        now_post = PostFactory.create(published=now)
+        sleep(.01)  # make `created` different for each post
+        yesterday_post = PostFactory.create(published=yesterday)
+        posts = self.perform(draft=False)
+        by_published_desc = sorted(
+            posts, key=lambda post: post['published'], reverse=True)
+        self.assertListEqual(
+            [p['id'] for p in by_published_desc],
+            [now_post.pk, yesterday_post.pk],
+        )
+
+    def test_filter_draft_returns_drafts_only(self):
+        # Create a draft
+        PostFactory.create()
+        # And a published post
+        post = PostFactory.create()
+        post.publish()
+
+        posts = self.perform(draft=True)
+
+        self.assertEqual(len(posts), 1)
+        self.assertNotIn(post.pk, map(lambda post: post['id'], posts))
+        for post in posts:
+            self.assertTrue(post['is_draft'])

--- a/tests/test_blog/test_post_list.py
+++ b/tests/test_blog/test_post_list.py
@@ -1,9 +1,7 @@
 """Test list of blog posts."""
 
 from typing import List
-from time import sleep
-from django.utils import timezone
-from datetime import timedelta
+
 from rest_framework.test import APITestCase
 from tests.decorators import authenticated
 
@@ -45,41 +43,3 @@ class PostListTest(APITestCase):
         posts = self.perform()
         expected = _POST_FIELDS
         self.assertSetEqual(expected, set(posts[0]))
-
-    def test_filter_by_slug(self):
-        post = PostFactory.create(title='Hello, world!', slug='hello-world')
-        posts = self.perform(slug=post.slug)
-        self.assertEqual(len(posts), 1)
-        self.assertEqual(posts[0]['slug'], 'hello-world')
-
-    def test_filter_not_draft_returns_published_only(self):
-        post = PostFactory.create()
-        post.publish()
-        posts = self.perform(draft=False)
-        self.assertEqual(len(posts), 1)
-        post_data = posts[0]
-        self.assertEqual(post_data['id'], post.pk)
-        self.assertFalse(post_data['is_draft'])
-
-    def test_filter_not_draft_returns_in_published_date_order(self):
-        now = timezone.now()
-        yesterday = timezone.now() - timedelta(days=1)
-        now_post = PostFactory.create(published=now)
-        sleep(.1)
-        yesterday_post = PostFactory.create(published=yesterday)
-        posts = self.perform(draft=False)
-        by_published_desc = sorted(
-            posts, key=lambda post: post['published'], reverse=True)
-        self.assertListEqual(
-            [p['id'] for p in by_published_desc],
-            [now_post.pk, yesterday_post.pk],
-        )
-
-    def test_filter_draft_returns_drafts_only(self):
-        post = PostFactory.create()
-        post.publish()
-        posts = self.perform(draft=True)
-        self.assertEqual(len(posts), 3)
-        self.assertNotIn(post.pk, map(lambda post: post['id'], posts))
-        for post in posts:
-            self.assertTrue(post['is_draft'])

--- a/tests/test_blog/test_post_search.py
+++ b/tests/test_blog/test_post_search.py
@@ -1,0 +1,36 @@
+"""Test searching the list of blog posts."""
+
+from rest_framework.test import APITestCase
+from tests.decorators import authenticated
+
+from blog.factories import PostFactory
+
+
+@authenticated
+class PostSearchListTest(APITestCase):
+    """Test searching on the post list endpoint."""
+
+    def setUp(self):
+        self.post1 = PostFactory.create(title='Getting Started With Python')
+        self.post2 = PostFactory.create(title='Test', slug='foo')
+        self.post3 = PostFactory.create(tags=['docker'])
+
+    def search(self, term: str):
+        url = '/api/posts/'
+        response = self.client.get(url, {'search': term})
+        self.assertEqual(response.status_code, 200)
+        return response.data['results']
+
+    def test_returns_posts_matching_title(self):
+        results = self.search('Python')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['id'], self.post1.pk)
+
+    def test_returns_posts_matching_slug(self):
+        results = self.search('foo')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['id'], self.post2.pk)
+
+    def test_does_not_return_posts_matching_tags(self):
+        results = self.search('docker')
+        self.assertEqual(len(results), 0)


### PR DESCRIPTION
# Description

Add ability to search through the list of posts, e.g. using `/api/posts?search=Python`.